### PR TITLE
Fix CPU usage panel: replace removed cAdvisor metrics with kube-state-metrics

### DIFF
--- a/dashboards/keycloak-troubleshooting-dashboard.json
+++ b/dashboards/keycloak-troubleshooting-dashboard.json
@@ -714,7 +714,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"keycloak\", namespace=\"$namespace\"}[5m])) by (pod) /\nsum(container_spec_cpu_quota{container=\"keycloak\", namespace=\"$namespace\"}/container_spec_cpu_period{container=\"keycloak\", namespace=\"$namespace\"}) by (pod)",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"keycloak\", namespace=\"$namespace\"}[5m])) by (pod)\n/\non(pod) group_left\nsum(kube_pod_container_resource_limits{container=\"keycloak\", namespace=\"$namespace\", resource=\"cpu\"}) by (pod)",
               "hide": false,
               "legendFormat": "__auto",
               "range": true,


### PR DESCRIPTION
   Fixes #10 
   
   ## Summary
   
   The "KUBERNETES - CPU Usage percentage" panel in `keycloak-troubleshooting-dashboard.json` uses
   `container_spec_cpu_quota` and `container_spec_cpu_period` which were removed from cAdvisor/kubelet
   in Kubernetes 1.25+, causing the panel to show no data on modern clusters.
   
   ## Changes
   
   Replaced the deprecated cAdvisor metrics with `kube_pod_container_resource_limits` from
   kube-state-metrics (available since v2.0, 2021). The new query is backwards compatible.
   

